### PR TITLE
Add drift kernel adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.4|^8.0",
         "antidot-fw/framework": "^0.2.0",
         "beberlei/assert": "^3.3",
-        "drift/server": "^0.1.18",
+        "drift/server": "^0.1.20",
         "psr/container": "^1.0.0",
         "ramsey/uuid": "^4.1",
         "react/http": "^1.2"
@@ -62,5 +62,8 @@
         "laminas": {
             "config-provider": "Antidot\\React\\Container\\Config\\ConfigProvider"
         }
+    },
+    "suggest": {
+        "react/filesystem": "^0.1.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "test": "phpunit --colors=always"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "discard-changes": true
     },
     "extra": {
         "laminas": {

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "php": "^7.4|^8.0",
         "antidot-fw/framework": "^0.2.0",
         "beberlei/assert": "^3.3",
+        "drift/server": "^0.1.18",
         "psr/container": "^1.0.0",
         "ramsey/uuid": "^4.1",
         "react/http": "^1.2"

--- a/src/Container/Config/ConfigProvider.php
+++ b/src/Container/Config/ConfigProvider.php
@@ -33,16 +33,7 @@ class ConfigProvider
                     Socket::class => SocketFactory::class,
                 ],
             ],
-            'console' => [
-                'commands' => [
-                    'server:run' => RunServerCommand::class,
-                    'server:watch' => WatchServerCommand::class
-                ],
-                'factories' => [
-                    RunServerCommand::class => RunServerCommandFactory::class,
-                    WatchServerCommand::class => WatchServerCommandFactory::class,
-                ],
-            ],
+            'console' => $this->getConsoleConfig(),
             'server' => [
                 'host' => '0.0.0.0',
                 'port' => 5555,
@@ -52,5 +43,30 @@ class ConfigProvider
                 'static_folder' => 'public'
             ]
         ];
+    }
+
+    private function getConsoleConfig(): array
+    {
+        $hasWatcher = class_exists(WatchServerCommand::class);
+
+        return $hasWatcher
+            ? [
+                'commands' => [
+                    'server:run' => RunServerCommand::class,
+                    'server:watch' => WatchServerCommand::class
+                ],
+                'factories' => [
+                    RunServerCommand::class => RunServerCommandFactory::class,
+                    WatchServerCommand::class => WatchServerCommandFactory::class,
+                ]
+            ]
+            : [
+                'commands' => [
+                    'server:run' => RunServerCommand::class,
+                ],
+                'factories' => [
+                    RunServerCommand::class => RunServerCommandFactory::class,
+                ]
+            ];
     }
 }

--- a/src/Container/Config/ConfigProvider.php
+++ b/src/Container/Config/ConfigProvider.php
@@ -5,8 +5,12 @@ namespace Antidot\React\Container\Config;
 use Antidot\Application\Http\Application;
 use Antidot\React\LoopFactory;
 use Antidot\React\ReactApplicationFactory;
+use Antidot\React\RunServerCommandFactory;
 use Antidot\React\ServerFactory;
 use Antidot\React\SocketFactory;
+use Antidot\React\WatchServerCommandFactory;
+use Drift\Server\Console\RunServerCommand;
+use Drift\Server\Console\WatchServerCommand;
 use React\EventLoop\LoopInterface;
 use React\Http\Server;
 use React\Socket\Server as Socket;
@@ -29,12 +33,23 @@ class ConfigProvider
                     Socket::class => SocketFactory::class,
                 ],
             ],
+            'console' => [
+                'commands' => [
+                    'server:run' => RunServerCommand::class,
+                    'server:watch' => WatchServerCommand::class
+                ],
+                'factories' => [
+                    RunServerCommand::class => RunServerCommandFactory::class,
+                    WatchServerCommand::class => WatchServerCommandFactory::class,
+                ],
+            ],
             'server' => [
+                'host' => '0.0.0.0',
+                'port' => 5555,
+                'buffer_size' => 4096,
+                'max_concurrency' => 100,
                 'workers' => 1,
-                'host' => self::DEFAULT_HOST,
-                'port' => self::DEFAULT_PORT,
-                'max_concurrency' => self::DEFAULT_CONCURRENCY,
-                'buffer_size' => self::DEFAULT_BUFFER_SIZE,
+                'static_folder' => 'public'
             ]
         ];
     }

--- a/src/DriftKernelAdapter.php
+++ b/src/DriftKernelAdapter.php
@@ -71,7 +71,7 @@ final class DriftKernelAdapter implements KernelAdapter
 
     public static function getStaticFolder(): ?string
     {
-        return '/public';
+        return 'public';
     }
 
     public function shutDown(): PromiseInterface

--- a/src/DriftKernelAdapter.php
+++ b/src/DriftKernelAdapter.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Antidot\React;
+
+use Antidot\Application\Http\Application;
+use Drift\Console\OutputPrinter;
+use Drift\Server\Adapter\KernelAdapter;
+use Drift\Server\Context\ServerContext;
+use Drift\Server\Mime\MimeTypeChecker;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\LoopInterface;
+use React\Filesystem\FilesystemInterface;
+use React\Promise\PromiseInterface;
+use function React\Promise\resolve;
+
+final class DriftKernelAdapter implements KernelAdapter
+{
+    private FilesystemInterface $filesystem;
+    private ServerContext $serverContext;
+    private MimeTypeChecker $mimeTypeChecker;
+    private string $rootPath;
+    private ContainerInterface $container;
+    private ReactApplication $application;
+
+    public function __construct(
+        ServerContext $serverContext,
+        FilesystemInterface $filesystem,
+        MimeTypeChecker $mimeTypeChecker,
+        string $rootPath
+    ) {
+        $container = require $rootPath . '/config/container.php';
+        assert($container instanceof ContainerInterface);
+        $application = $container->get(Application::class);
+        assert($application instanceof ReactApplication);
+        (require $rootPath . '/router/middleware.php')($application, $container);
+        (require $rootPath . '/router/routes.php')($application, $container);
+        $this->container = $container;
+        $this->application = $application;
+        $this->serverContext = $serverContext;
+        $this->filesystem = $filesystem;
+        $this->mimeTypeChecker = $mimeTypeChecker;
+        $this->rootPath = $rootPath;
+    }
+
+    /** @psalm-suppress MixedReturnTypeCoercion */
+    public static function create(
+        LoopInterface $loop,
+        string $rootPath,
+        ServerContext $serverContext,
+        FilesystemInterface $filesystem,
+        OutputPrinter $outputPrinter,
+        MimeTypeChecker $mimeTypeChecker
+    ): PromiseInterface {
+
+        return resolve(new self($serverContext, $filesystem, $mimeTypeChecker, $rootPath))
+            ->then(fn (KernelAdapter $adapter): KernelAdapter => $adapter);
+    }
+
+    /**
+     * @psalm-suppress LessSpecificImplementedReturnType
+     * @param ServerRequestInterface $request
+     * @return PromiseResponse
+     */
+    public function handle(ServerRequestInterface $request): PromiseResponse
+    {
+        return $this->application->handle($request);
+    }
+
+    public static function getStaticFolder(): ?string
+    {
+        return '/public';
+    }
+
+    public function shutDown(): PromiseInterface
+    {
+        return resolve('nothing to do');
+    }
+
+    /**
+     * Get watcher folders.
+     *
+     * @return string[]
+     */
+    public static function getObservableFolders(): array
+    {
+        return ['src', 'public', 'templates'];
+    }
+
+    /**
+     * Get watcher folders.
+     *
+     * @return string[]
+     */
+    public static function getObservableExtensions(): array
+    {
+        return ['php', 'yml', 'yaml', 'xml', 'css', 'js', 'html', 'twig'];
+    }
+
+    /**
+     * Get watcher ignoring folders.
+     *
+     * @return string[]
+     */
+    public static function getIgnorableFolders(): array
+    {
+        return ['var'];
+    }
+}

--- a/src/ReactApplication.php
+++ b/src/ReactApplication.php
@@ -107,6 +107,10 @@ class ReactApplication implements Application, RequestHandlerInterface, Middlewa
             ));
     }
 
+    /**
+     * @param ServerRequestInterface $request
+     * @return PromiseResponse
+     */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         return new PromiseResponse(resolve($request)

--- a/src/RunServerCommandFactory.php
+++ b/src/RunServerCommandFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Antidot\React;
+
+use Drift\Server\Console\RunServerCommand;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class RunServerCommandFactory
+{
+    public function __invoke(ContainerInterface $container): RunServerCommand
+    {
+        /** @var array<string, array> $globalConfig */
+        $globalConfig = $container->get('config');
+        /** @var array<string, string|int> $config */
+        $config = $globalConfig['server'];
+
+        $command = new RunServerCommand(dirname('./'), 'server:run');
+        $command->setDescription('Run Drift HTTP Server');
+        $definition = $command->getDefinition();
+
+        $path = new InputArgument('path', InputArgument::OPTIONAL, $definition->getArgument('path')->getDescription());
+        $path->setDefault(sprintf('%s:%s', $config['host'], $config['port']));
+        $definition->setArguments([$path]);
+
+        $adapter = $definition->getOption('adapter');
+        $adapter->setDefault(DriftKernelAdapter::class);
+        $staticFolder = $definition->getOption('static-folder');
+        $staticFolder->setDefault($config['static_folder']);
+        $workers = $definition->getOption('workers');
+        $workers->setDefault($config['workers']);
+        $concurrentRequests = $definition->getOption('concurrent-requests');
+        $concurrentRequests->setDefault($config['max_concurrency']);
+        $bufferSize = $definition->getOption('request-body-buffer');
+        $bufferSize->setDefault($config['buffer_size']);
+
+        return $command;
+    }
+}

--- a/src/WatchServerCommandFactory.php
+++ b/src/WatchServerCommandFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Antidot\React;
+
+use Drift\Server\Console\WatchServerCommand;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class WatchServerCommandFactory
+{
+    public function __invoke(ContainerInterface $container): WatchServerCommand
+    {
+        /** @var array<string, array> $globalConfig */
+        $globalConfig = $container->get('config');
+        /** @var array<string, string|int> $config */
+        $config = $globalConfig['server'];
+
+        $command = new WatchServerCommand(dirname('./'), [
+            'bin/console',
+            'server:run',
+            sprintf('--adapter=%s', DriftKernelAdapter::class),
+            '--debug',
+        ], 'server:watch');
+        $definition = $command->getDefinition();
+        $command->setDescription('Watch Drift HTTP Server for development purposes');
+
+        $path = new InputArgument('path', InputArgument::OPTIONAL, $definition->getArgument('path')->getDescription());
+        $path->setDefault(sprintf('%s:%s', $config['host'], $config['port']));
+        $definition->setArguments([$path]);
+
+        $staticFolder = $definition->getOption('static-folder');
+        $staticFolder->setDefault($config['static_folder']);
+        $concurrentRequests = $definition->getOption('concurrent-requests');
+        $concurrentRequests->setDefault($config['max_concurrency']);
+        $bufferSize = $definition->getOption('request-body-buffer');
+        $bufferSize->setDefault($config['buffer_size']);
+
+        return $command;
+    }
+}

--- a/test/Container/Config/ConfigProviderTest.php
+++ b/test/Container/Config/ConfigProviderTest.php
@@ -1,13 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AntidotTest\React\Container\Config;
 
 use Antidot\Application\Http\Application;
 use Antidot\React\Container\Config\ConfigProvider;
 use Antidot\React\LoopFactory;
 use Antidot\React\ReactApplicationFactory;
+use Antidot\React\RunServerCommandFactory;
 use Antidot\React\ServerFactory;
 use Antidot\React\SocketFactory;
+use Antidot\React\WatchServerCommandFactory;
+use Drift\Server\Console\RunServerCommand;
+use Drift\Server\Console\WatchServerCommand;
 use PHPUnit\Framework\TestCase;
 use React\EventLoop\LoopInterface;
 use React\Http\Server;
@@ -29,12 +35,23 @@ class ConfigProviderTest extends TestCase
                         Socket::class => SocketFactory::class,
                     ]
                 ],
+                'console' => [
+                    'commands' => [
+                        'server:run' => RunServerCommand::class,
+                        'server:watch' => WatchServerCommand::class
+                    ],
+                    'factories' => [
+                        RunServerCommand::class => RunServerCommandFactory::class,
+                        WatchServerCommand::class => WatchServerCommandFactory::class,
+                    ],
+                ],
                 'server' => [
-                    'workers' => 1,
                     'host' => '0.0.0.0',
-                    'port' => 8080,
+                    'port' => 5555,
+                    'buffer_size' => 4096,
                     'max_concurrency' => 100,
-                    'buffer_size' => 4194304,
+                    'workers' => 1,
+                    'static_folder' => 'public'
                 ]
             ],
             $configProvider(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As talked with @mmoreram([DriftPHP](https://github.com/driftphp) lead developer) we will integrate the reactive versión of Antidot with DriftPHP Server:

Comparing to the actual plain ReactPHP server, the Drift server gives us more robustness and some features like static file serving, multi-threading, server logs, request timing... A big step up;- D

Also, this way we can focus on working on more specific framework related features and of course helping in the Driftphp community